### PR TITLE
Allow discontinuous field ranges

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -58,12 +58,13 @@ function calculate_ranges(columnwidths::Union{Vector{UnitRange{Int}}, Vector{Int
             l=last(rangewidths[i])
         end
     else
-        #Validate we have an unbroken range wile copying
+        #Validate the passed ranges
         first(first(columnwidths)) <= 0 && (throw(ArgumentError("Columns must start > 0")))
         for i in 1:length(columnwidths)
+            first(columnwidths[i]) ≤ last(columnwidths[i]) || throw(ArgumentError(string("Negative range ", columnwidths[i])))
             rangewidths[i] = columnwidths[i]
             i==1 && (continue)
-            (last(columnwidths[i-1])+1 != first(columnwidths[i])) && (throw(ArgumentError("Non-Continuous ranges "*string(columnwidths[i-1])*","*string(columnwidths[i])))) 
+            (last(columnwidths[i-1]) < first(columnwidths[i])) || (throw(ArgumentError("Non-increasing ranges "*string(columnwidths[i-1])*","*string(columnwidths[i]))))
         end
     end
     return rangewidths
@@ -123,8 +124,7 @@ function Source(
     columns = length(columnwidths)
 
     rangewidths = calculate_ranges(columnwidths)
-    rowlength = last(last(rangewidths))
-        
+
     # Starting position
     startpos = position(source)
     # rows to process, subtract skip and header if they exist

--- a/test/Source.jl
+++ b/test/Source.jl
@@ -62,7 +62,8 @@ end
     # Range building
     @test_throws ArgumentError FWF.calculate_ranges([-1,2,3])
     @test_throws ArgumentError FWF.calculate_ranges([-1:2])
-    @test_throws ArgumentError FWF.calculate_ranges([1:2, 4:5])
+    @test_throws ArgumentError FWF.calculate_ranges([1:2, 1:5])
+    @test_throws ArgumentError FWF.calculate_ranges([1:5, 6:5])
     tmp = FWF.calculate_ranges([1,4,6])
     @test tmp[1] == 1:1
     @test tmp[2] == 2:5

--- a/test/io.jl
+++ b/test/io.jl
@@ -46,6 +46,43 @@ end
     @test s[2] == "5678"
     @test s[3] == "10112017"
     @test_throws ArgumentError FWF.readsplitline!(s, tmp)
+
+    tmp = FWF.Source(file, [4,4,4])
+    FWF.readsplitline!(s, tmp)
+    @test s[1] == "abcd"
+    @test s[2] == "1234"
+    @test s[3] == "1010"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp.io, Vector{UnitRange{Int}}())
+    FWF.readsplitline!(s, tmp)
+    @test s[1] == "efgh"
+    @test s[2] == "5678"
+    @test s[3] == "1011"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp)
+
+    tmp = FWF.Source(file, [1:4,5:8,9:16])
+    FWF.readsplitline!(s, tmp)
+    @test s[1] == "abcd"
+    @test s[2] == "1234"
+    @test s[3] == "10102017"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp.io, Vector{UnitRange{Int}}())
+    FWF.readsplitline!(s, tmp)
+    @test s[1] == "efgh"
+    @test s[2] == "5678"
+    @test s[3] == "10112017"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp)
+
+    tmp = FWF.Source(file, [1:2,5:6,9:10])
+    FWF.readsplitline!(s, tmp)
+    @test s[1] == "ab"
+    @test s[2] == "12"
+    @test s[3] == "10"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp.io, Vector{UnitRange{Int}}())
+    FWF.readsplitline!(s, tmp)
+    @test s[1] == "ef"
+    @test s[2] == "56"
+    @test s[3] == "10"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp)
+
     b="""
     aaaa
     bbb


### PR DESCRIPTION
In this patch I allow ranges as `[1:3, 5:6]`. Additionally I add a check for negative range (which was missing) and improve documentation of `FWF.read`.

The current behavior is that we silently allow lines longer than maximum width implied by `columnwidths`. This is OK for me, but if you want a stricter width checking we can reintroduce it later.