### PR TITLE
add check if all valid line lengths are equal

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -12,6 +12,7 @@ mutable struct Source{I} <: Data.Source
     lastcol::Int
     malformed::Bool # file is malformed so slow parsing
     eolpad::Int #Number of characters to pad at end of line (typically=0, 1 for CRLF files)
+    line_len::Int # first line length successfully parsed by readsplitline!
 end
 
 function Base.show(io::IO, f::Source)
@@ -148,11 +149,12 @@ function Source(
         tmp =- 1     
     end
     datapos = position(source)
+    line_len = -1
 
     # Figure out headers
     if isa(header, Bool) && header
         # first row is heders
-        FWF.readsplitline!(headerlist, source, rangewidths, true)
+        line_len = FWF.readsplitline!(headerlist, source, rangewidths, true)
         datapos = position(source)
         for i in eachindex(headerlist)
             length(headerlist[i]) < 1 && (headerlist[i] = "Column$i")
@@ -203,7 +205,7 @@ function Source(
                     skiponerror=skiponerror, unitbytes=unitbytes, skip=skip, missingvals=missingdict, 
                     dateformats = datedict,
                     columnrange=rangewidths)
-    return Source(sch, opt, source, string(fullpath), datapos, Vector{String}(), 0, malformed, eolpad)
+    return Source(sch, opt, source, string(fullpath), datapos, Vector{String}(), 0, malformed, eolpad, line_len)
 end
 
 # needed? construct a new Source from a Sink

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -33,7 +33,9 @@ function parsefield(source::FWF.Source, ::Type{T}, row::Int, col::Int) where {T}
         throw(FWF.ParsingException("Out of order access col=$col lastcol=$(source.lastcol)"))
     end
     source.lastcol = col
-    col == 1 && (readsplitline!(source.currentline, source))
+    if col == 1
+        readsplitline!(source.currentline, source)
+    end
     
     if missingon(source) && checkmissing(source.currentline[col], source.options.missingvals)
         return missing

--- a/test/io.jl
+++ b/test/io.jl
@@ -88,16 +88,43 @@ end
     bbb
     cccc"""
     tmp = FWF.Source(IOBuffer(b),[4])
-    @test FWF.readsplitline!(s, tmp)[1] == "aaaa"
-    @test FWF.readsplitline!(s, tmp)[1] == "cccc"
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "aaaa"
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "cccc"
     # Not error until malformed is back
     #@test_throws FWF.ParsingException FWF.Source(IOBuffer(b),[4],skiponerror=false)
     tmp = FWF.Source(IOBuffer(b),[4], skiponerror=true)
-    @test FWF.readsplitline!(s, tmp)[1] == "aaaa"
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "aaaa"
     @test tmp.schema.rows == 3
     #@test_throws FWF.ParsingException FWF.readsplitline!(s, tmp)
-    @test FWF.readsplitline!(s, tmp)[1] == "cccc"
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "cccc"
+
+    # test overlong line
+    b="""
+    aaaa
+    bbb
+    ccccc"""
+    tmp = FWF.Source(IOBuffer(b),[4])
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "aaaa"
+    @test FWF.readsplitline!(s, tmp) == 5
+    @test s[1] == "cccc"
     
+
+    # test overlong line
+    b="""
+    aaaaa
+    bbb
+    cccc"""
+    tmp = FWF.Source(IOBuffer(b),[4])
+    @test FWF.readsplitline!(s, tmp) == 5
+    @test s[1] == "aaaa"
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "cccc"
+
     #ensure utf 8 doesn't mess us up
     b = """
     abcd
@@ -105,12 +132,13 @@ end
     fghi
     """
     tmp = FWF.Source(IOBuffer(b),[4])
-    @test FWF.readsplitline!(s, tmp)[1] == "abcd"
-    @test FWF.readsplitline!(s, tmp)[1] == "\u263ae"
-    @test FWF.readsplitline!(s, tmp)[1] == "fghi"
-    @test_throws ArgumentError FWF.readsplitline!(s, tmp)[1]
-
-
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "abcd"
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "\u263ae"
+    @test FWF.readsplitline!(s, tmp) == 4
+    @test s[1] == "fghi"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp)
 end
 
 @testset "FWF.read Testing" begin


### PR DESCRIPTION
This implements the check if all valid lines in FWF file have equal length. As noted in #4 the only thing we can do is issue a warning that something is wrong, but in general we do not know which line is wrong.

Also redirected warnings to `STDERR` from `STDOUT` as it was implemented earlier.

The functionality adds `line_len` field to `Source` which keeps information about length of first valid line in source (in bytes or characters depending on the `usebytes` option). This field has value `-1` initially and is changed to the first valid line length. Then every time we encounter a line of a different length a warning to `STDERR` is sent.