### PR TITLE
Code Cleanup Column Parsing, Macros, Type Stability

### DIFF
--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -40,7 +40,7 @@ function parsefield(source::FWF.Source, ::Type{T}, row::Int, col::Int) where {T}
     tmp = source.currentline[col]
     ismissing(tmp) && return missing
     # We know ref is a string
-    ref = tmp::String
+    ref::String = tmp
     if missingon(source) && checkmissing(ref, source.options.missingvals)
         return missing
     end

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -16,8 +16,8 @@ The parameter list without a row results in a whole column being streamed from t
 """
 function parsefield end
 
-@inline missingon(source::FWF.Source) = (source.options.usemissings)
-@inline checkmissing(key::String, d::Dict{String, Missing}) = (haskey(d, key)) 
+missingon(source::FWF.Source) = (source.options.usemissings)
+checkmissing(key::String, d::Dict{String, Missing}) = (haskey(d, key)) 
 
 function get_format(source::FWF.Source, col::Int) 
     !haskey(source.options.dateformats, col) && return nothing
@@ -50,10 +50,10 @@ end
 
 # Batch of simple parsers to convert strings
 usemissing_or_val(b, v) = b ? missing : v
-@static if VERSION >= v"0.7.0-DEV"
-    @inline null_to_missing(x, b, v) = x == nothing ? usemissing_or_val(b, v) : x
+if VERSION >= v"0.7.0-DEV"
+    null_to_missing(x, b, v) = x == nothing ? usemissing_or_val(b, v) : x
 else
-    @inline null_to_missing(x, b, v) = isnull(x) ? usemissing_or_val(b, v)  : unsafe_get(x)
+    null_to_missing(x, b, v) = isnull(x) ? usemissing_or_val(b, v)  : unsafe_get(x)
 end
 
 parsefield(::Type{Int}, usemissing::Bool, string::String, format) = 
@@ -63,9 +63,9 @@ parsefield(::Type{Float64}, usemissing::Bool, string::String, format) =
 parsefield(::Type{String}, usemissing::Bool, string::String, format) = string
 parsefield(::Type{Date}, usemissing::Bool, string::String, format) = 
     null_to_missing(tryparse(Date, string, format), usemissing, Date())
-@inline parsefield(::Type{Union{Missing, T}}, usemissing::Bool, string::String, format) where {T} = 
+parsefield(::Type{Union{Missing, T}}, usemissing::Bool, string::String, format) where {T} = 
     (parsefield(T, usemissing, string, format))
-@inline parsefield(::Type{Missing}, usemissing::Bool, string::String, format) = (missing)
+parsefield(::Type{Missing}, usemissing::Bool, string::String, format) = (missing)
 
 # Generic fallback
 function parsefield(T, usemissing::Bool, string::String, format)

--- a/test/FWF.jl
+++ b/test/FWF.jl
@@ -11,4 +11,18 @@
     @test x.missingvals == Dict{String, Missing}()
     @test x.dateformats == Dict{Int, DateFormat}()
     @test x.columnrange == Vector{UnitRange{Int}}()
+
+    m = Dict{String, Missing}("***" => missing)
+    d = Dict{Int, DateFormat}(1 => DateFormat("mmddyy"))
+    x = [1:10, 2:20]
+    tmp = FWF.Options(usemissings = false, trimstrings = false, errorlevel = :skip,
+                    unitbytes = false, skip = 10, missingvals = m, dateformats = d, columnrange = x)  
+    @test tmp.usemissings == false
+    @test tmp.trimstrings == false
+    @test tmp.errorlevel == :skip
+    @test tmp.unitbytes == false
+    @test tmp.skip == 10
+    @test tmp.missingvals == m
+    @test tmp.dateformats == d
+    @test tmp.columnrange == x
 end

--- a/test/Source.jl
+++ b/test/Source.jl
@@ -15,11 +15,12 @@ file = joinpath(dir,"testfile.txt")
     @test_throws ArgumentError FWF.Source(file, [4,4,8], types=[String, Float32, DateFormat("mmddyyyy")])
 
     tmp = FWF.Source(file, [4,4,8])
+    show(IOBuffer(), tmp) # Will retult in exception if problem unfortunately there is no @test_notthrows
     @test Data.header(tmp.schema)[1] == "Column1"
     @test Data.header(tmp.schema)[2] == "Column2"
     @test Data.header(tmp.schema)[3] == "Column3"
 
-    tmp = FWF.Source(file, [4,4,8], header=true)
+    tmp = FWF.Source(open(file, "r"), [4,4,8], header=true)
     @test Data.header(tmp.schema)[1] == "abcd"
     @test Data.header(tmp.schema)[2] == "1234"
     @test Data.header(tmp.schema)[3] == "10102017"
@@ -49,16 +50,6 @@ end
     abc
     def"""
 
-    # @test FWF.row_calc(FWF.row_countlines(IOBuffer(b))[1], 0, 0, true) == 1
-    # @test FWF.row_calc(FWF.row_countlines(IOBuffer(b))[1], 0, 0, false) == 2
-    # @test FWF.row_calc(FWF.row_countlines(IOBuffer(b))[1], 0, 0) == 2
-    # @test FWF.row_calc(FWF.row_countlines(IOBuffer(b))[1], 0, 2) == 0
-    # @test FWF.row_calc(FWF.row_countlines(IOBuffer(b))[1], 1, 0) == 1
-    # @test FWF.row_calc(FWF.row_countlines(IOBuffer(b))[1], -1, 0) == 2
-    # @test FWF.row_calc(FWF.row_countlines(IOBuffer(b))[1], 0, -1) == 2
-    #@test_throws ArgumentError FWF.row_calc(IOBuffer(b), 0, 3)
-    #@test_throws ArgumentError FWF.row_calc(IOBuffer(b), 0, 2, true)
-    
     # Range building
     @test_throws ArgumentError FWF.calculate_ranges([-1,2,3])
     @test_throws ArgumentError FWF.calculate_ranges([-1:2])

--- a/test/io.jl
+++ b/test/io.jl
@@ -82,6 +82,13 @@ end
     @test s[2] == "56"
     @test s[3] == "10"
     @test_throws ArgumentError FWF.readsplitline!(s, tmp)
+    Data.reset!(tmp)
+    @test Data.accesspattern(tmp) == Data.Sequential() # not sure why this isn't a type
+    FWF.readsplitline!(s, tmp)
+    @test s[1] == "ab"
+    @test s[2] == "12"
+    @test s[3] == "10"
+    @test_throws ArgumentError FWF.readsplitline!(s, tmp.io, Vector{UnitRange{Int}}())
 
     b="""
     aaaa

--- a/test/parsefields.jl
+++ b/test/parsefields.jl
@@ -16,7 +16,7 @@ file = joinpath(dir,"testfile.txt")
     @test FWF.parsefield(tmp, Int, 1, 2) == 1234
     @test FWF.parsefield(tmp, Date, 1, 3) == Date("2017-10-10")
     @test FWF.parsefield(tmp, String, 2, 1) == "efgh"
-    @test FWF.parsefield(tmp, Int, 2, 2) == 5678
+    @test ismissing(FWF.parsefield(tmp, Missing, 2, 2))
     @test ismissing(FWF.parsefield(tmp, Date, 2, 3))
     @test_throws BoundsError FWF.parsefield(tmp, Date, 2, 4)
     b = """


### PR DESCRIPTION
The existing column based parsing code has little value so it has been removed.  There were also a number of macros using the file that were unnecessary compiler hints that have been removed.   Also made some minor changes to reduce type instability as much as possible.   