### PR TITLE
change missingvals from Dict to Set and several minor changes

### DIFF
--- a/src/FWF.jl
+++ b/src/FWF.jl
@@ -21,9 +21,9 @@ Configuration Settings for fixed width file parsing.
   * `usemissings` : true if fields should be checked for null values; default `true`
   * `errorlevel`  : if `:parse` then as much as possible is parsed and missing data is replaced by `missing`;
                     if `:skip` then malformed line is skipped on error;
-                    on any other value an exception is thrown on error; default `:parse`
+                    if `:error` then an exception is thrown on error; default `:parse`
   * `countnybytes`: true if field parsing should happen by bytes, false for character based parsing; default `true` 
-  * `missingvals` : Dictionary in form of String=>missing for values that equal missing
+  * `missingvals` : Set{String} for values that equal missing
   * `dateformats` : Dictionary in the form of Int=>DateFormat to specify date formats for a column
   * `columnrange` : Vector of UnitRanges that specifcy the widths of each column.
   * ``
@@ -35,18 +35,21 @@ struct Options
     errorlevel::Symbol
     unitbytes::Bool
     skip::Int
-    missingvals::Dict{String, Missing}
+    missingvals::Set{String}
     dateformats::Dict{Int, DateFormat}
     columnrange::Vector{UnitRange{Int}}
 end
 
 function Options(;usemissings=true, trimstrings=true, errorlevel=:parse, unitbytes=true,
-                 skip=0, missingvals=Dict{String, Missing}(),
+                 skip=0, missingvals=Set{String}(),
                  dateformats=Dict{Int, DateFormat}(), columnrange=Vector{UnitRange{Int}}())
     if !usemissings && (errorlevel == :parse)
         println(STDERR, "Warning: Combination of usemissings==false and errorlevel==:parse\n"*
                "will lead to an error when malformed lines are present in the data.\n"*
                "In order to avoid this set usemissings to true or errorlevel to :skip.")
+    end
+    if !(errorlevel in [:parse, :skip, :error])
+        throw(ArgumentError("Allowed values for errorlevel are :parse, :skip or :error"))
     end
     Options(usemissings, trimstrings, errorlevel, unitbytes,
             skip, missingvals, dateformats, columnrange)

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -97,7 +97,6 @@ function Source(
     # Appemtping to re-create all objects here to minimize outside tampering
     datedict = Dict{Int, DateFormat}()
     typelist = Vector{DataType}()
-    missingdict = Dict{String, Missing}()
     rangewidths = Vector{UnitRange{Int}}()
     malformed = false
 
@@ -200,16 +199,12 @@ function Source(
         end
     end
 
-    # Convert missings to dictionary for faster lookup later.
-    if !isempty(missings)
-        for entry in missings
-            missingdict[entry] = missing
-        end
-    end
+    # Convert missings to Set for faster lookup later.
+    missingset=Set{String}(missings)
 
     sch = Data.Schema(typelist, headerlist, ifelse(rows ≤ 0, missing, rows))
     opt = Options(usemissings=usemissings, trimstrings=trimstrings, 
-                    errorlevel=errorlevel, unitbytes=unitbytes, skip=skip, missingvals=missingdict, 
+                    errorlevel=errorlevel, unitbytes=unitbytes, skip=skip, missingvals=missingset,
                     dateformats = datedict,
                     columnrange=rangewidths)
     return Source(sch, opt, source, string(fullpath), datapos, Vector{Union{Missing,String}}(), 0, malformed, eolpad, line_len)

--- a/src/io.jl
+++ b/src/io.jl
@@ -149,11 +149,11 @@ Keyword Arguments:
 
 * `unitbytes::Bool`: whether to treat field ranges in bytes or characters; default = true (bytes)
 * `usemissings::Bool`: whether to use missings, all fields will be unioned with Missing; default = true
-                        if not set default values of 0, date() and "" will be used for missing values
+                        if not set default values of 0, Date() and "" will be used for missing values
 * `trimstrings::Bool`: trim whitespace from all strings; default = true
 * `errorlevel`  : if `:parse` then as much as possible is parsed and missing data is replaced by `missing`;
                 if `:skip` then malformed line is skipped on error;
-                on any other value an exception is thrown on error; default `:parse`
+                if `:error` then an exception is thrown on error; default `:parse`
 * `use_mmap::Bool=true`: whether the underlying file will be mmapped or not while parsing; note that on Windows machines, the underlying file will not be "deletable" until Julia GC has run (can be run manually via `gc()`) due to the use of a finalizer when reading the file.
 * `skip::Int`: number of rows at start of file to skip; default = 0
 * `rows::Int`: maximum number of rows to read from file; default = 0 (whole file)

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -17,7 +17,7 @@ The parameter list without a row results in a whole column being streamed from t
 function parsefield end
 
 missingon(source::FWF.Source) = (source.options.usemissings)
-checkmissing(key::String, d::Dict{String, Missing}) = (haskey(d, key)) 
+checkmissing(key::String, d::Set{String}) = key in d
 
 function get_format(source::FWF.Source, col::Int) 
     !haskey(source.options.dateformats, col) && return nothing

--- a/test/FWF.jl
+++ b/test/FWF.jl
@@ -8,15 +8,15 @@
     @test x.errorlevel == :parse
     @test x.unitbytes == true
     @test x.skip == 0
-    @test x.missingvals == Dict{String, Missing}()
+    @test x.missingvals == Set{String}()
     @test x.dateformats == Dict{Int, DateFormat}()
     @test x.columnrange == Vector{UnitRange{Int}}()
 
-    m = Dict{String, Missing}("***" => missing)
+    m = Set{String}(["***"])
     d = Dict{Int, DateFormat}(1 => DateFormat("mmddyy"))
     x = [1:10, 2:20]
-    tmp = FWF.Options(usemissings = false, trimstrings = false, errorlevel = :skip,
-                    unitbytes = false, skip = 10, missingvals = m, dateformats = d, columnrange = x)  
+    tmp = FWF.Options(usemissings=false, trimstrings=false, errorlevel=:skip,
+                      unitbytes=false, skip=10, missingvals=m, dateformats=d, columnrange=x)
     @test tmp.usemissings == false
     @test tmp.trimstrings == false
     @test tmp.errorlevel == :skip
@@ -25,4 +25,8 @@
     @test tmp.missingvals == m
     @test tmp.dateformats == d
     @test tmp.columnrange == x
+
+    @test_throws ArgumentError FWF.Options(usemissings=false, trimstrings=false,
+                                           errorlevel=:x, unitbytes=false, skip=10,
+                                           missingvals=m, dateformats=d, columnrange=x)
 end

--- a/test/Source.jl
+++ b/test/Source.jl
@@ -41,8 +41,8 @@ file = joinpath(dir,"testfile.txt")
     @test Data.types(tmp.schema)[2] == Union{Missing, Int64}
     @test Data.types(tmp.schema)[3] == Union{Missing, Date}
     @test tmp.options.dateformats[3] == DateFormat("mmddyyyy")
-    @test haskey(tmp.options.missingvals, "***")
-    haskey(tmp.options.missingvals, "NA")
+    @test "***" in tmp.options.missingvals
+    @test "NA" in tmp.options.missingvals
 end
 
 @testset "Functions" begin


### PR DESCRIPTION
Small internal cleanup (`missingvals` is `Set` not `Dict`) and strictly allowing only `:parse`, `:skip` or `:error` values for `errorlevel` keyword argument.